### PR TITLE
Fixed broken link to 3dsMax-Python-HowTos repository in menu item

### DIFF
--- a/inbrowserhelp/inbrowserhelp/__init__.py
+++ b/inbrowserhelp/inbrowserhelp/__init__.py
@@ -8,7 +8,7 @@ TOPICS = [
     ("gettingstarted", "Getting Started With Python in 3ds Max",
      "help.autodesk.com/view/MAXDEV/2021/ENU/?guid=__developer_tutorials_creating_the_dialog_html"),
     ("howtos", "Python HowTos Github Repo",
-     "https://github.com/ADN-DevTech/3dsMax-Python-HowTos"),
+     "github.com/ADN-DevTech/3dsMax-Python-HowTos"),
     ("pymxs", "Pymxs Online Documentation",
      "help.autodesk.com/view/MAXDEV/2021/ENU/?guid=__developer_using_pymxs_html"),
     ("pyside2", "Qt for Python Documentation (PySide2)",


### PR DESCRIPTION
I just checked out the updated examples and it's great to see some working being done in this area 👍 
Stumbled upon this little issue and thought I would dig into all this git stuff and contribute.